### PR TITLE
Implement query committed chaincodes in channel

### DIFF
--- a/pkg/chaincode/lifecycle.go
+++ b/pkg/chaincode/lifecycle.go
@@ -12,6 +12,7 @@ const (
 	approveTransactionName              = "ApproveChaincodeDefinitionForMyOrg"
 	commitTransactionName               = "CommitChaincodeDefinition"
 	queryInstalledTransactionName       = "QueryInstalledChaincodes"
+	queryCommittedTransactionName       = "QueryChaincodeDefinitions"
 	checkCommitReadinessTransactionName = "CheckCommitReadiness"
 	installTransactionName              = "InstallChaincode"
 	// MetadataFile is the expected location of the metadata json document

--- a/pkg/chaincode/querycommitted.go
+++ b/pkg/chaincode/querycommitted.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hyperledger/fabric-admin-sdk/pkg/identity"
+	"github.com/hyperledger/fabric-admin-sdk/pkg/internal/proposal"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// QueryCommitted chaincode on a specific peer.
+func QueryCommitted(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, channelID string) (*lifecycle.QueryChaincodeDefinitionsResult, error) {
+	queryArgs := &lifecycle.QueryChaincodeDefinitionsArgs{}
+	queryArgsBytes, err := proto.Marshal(queryArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, queryCommittedTransactionName, proposal.WithArguments(queryArgsBytes), proposal.WithChannel(channelID))
+	if err != nil {
+		return nil, err
+	}
+
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
+	if err != nil {
+		return nil, err
+	}
+
+	endorser := peer.NewEndorserClient(connection)
+
+	proposalResponse, err := endorser.ProcessProposal(ctx, signedProposal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query committed chaincode: %w", err)
+	}
+
+	if err = proposal.CheckSuccessfulResponse(proposalResponse); err != nil {
+		return nil, err
+	}
+
+	result := &lifecycle.QueryChaincodeDefinitionsResult{}
+	if err = proto.Unmarshal(proposalResponse.GetResponse().GetPayload(), result); err != nil {
+		return nil, fmt.Errorf("failed to deserialize query committed chaincode result: %w", err)
+	}
+
+	return result, nil
+}

--- a/pkg/chaincode/querycommitted_test.go
+++ b/pkg/chaincode/querycommitted_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("QueryCommitted", func() {
+	It("Endorser client called with supplied context", func(specCtx SpecContext) {
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				return ctx.Err()
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		ctx, cancel := context.WithCancel(specCtx)
+		cancel()
+
+		_, err := QueryCommitted(ctx, mockConnection, mockSigner, "")
+
+		Expect(err).To(MatchError(context.Canceled))
+	})
+
+	It("Endorser client errors returned", func(specCtx SpecContext) {
+		expectedErr := errors.New("EXPECTED_ERROR")
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(expectedErr)
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
+
+		Expect(err).To(MatchError(expectedErr))
+	})
+
+	It("Unsuccessful proposal response gives error", func(specCtx SpecContext) {
+		expectedStatus := common.Status_BAD_REQUEST
+		expectedMessage := "EXPECTED_ERROR"
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(And(
+			ContainSubstring("%d", expectedStatus),
+			ContainSubstring(expectedStatus.String()),
+			ContainSubstring(expectedMessage),
+		))
+	})
+
+	It("Uses signer", func(specCtx SpecContext) {
+		expected := []byte("SIGNATURE")
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var signedProposal *peer.SignedProposal
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			}).
+			Times(1)
+
+		mockSigner := NewMockSigner(controller, "", nil, expected)
+
+		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
+		Expect(err).NotTo(HaveOccurred())
+
+		actual := signedProposal.GetSignature()
+		Expect(actual).To(BeEquivalentTo(expected))
+	})
+
+	It("Proposal includes creator", func(specCtx SpecContext) {
+		expected := &msp.SerializedIdentity{
+			Mspid:   "MSP_ID",
+			IdBytes: []byte("CREDENTIALS"),
+		}
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var signedProposal *peer.SignedProposal
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			}).
+			Times(1)
+
+		mockSigner := NewMockSigner(controller, expected.Mspid, expected.IdBytes, nil)
+
+		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
+		Expect(err).NotTo(HaveOccurred())
+
+		signatureHeader := AssertUnmarshalSignatureHeader(signedProposal)
+
+		actual := &msp.SerializedIdentity{}
+		AssertUnmarshal(signatureHeader.GetCreator(), actual)
+
+		AssertProtoEqual(expected, actual)
+	})
+
+	It("Committed chaincodes returned on successful proposal response", func(specCtx SpecContext) {
+		expected := &lifecycle.QueryChaincodeDefinitionsResult{
+			ChaincodeDefinitions: []*lifecycle.QueryChaincodeDefinitionsResult_ChaincodeDefinition{
+				{
+					Name:                "CHAINCODE_NAME",
+					Version:             "CHAINCODE_VERSION",
+					Sequence:            1,
+					EndorsementPlugin:   "ENDORSEMENT_PLUGIN",
+					ValidationPlugin:    "VALIDATION_PLUGIN",
+					ValidationParameter: []byte("VALIDATION_PARAMETER"),
+					InitRequired:        true,
+					Collections:         &peer.CollectionConfigPackage{},
+				},
+			},
+		}
+
+		response := NewProposalResponse(common.Status_SUCCESS, "")
+		response.Response.Payload = AssertMarshal(expected)
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(response, out)
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		actual, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
+		Expect(err).NotTo(HaveOccurred())
+
+		AssertProtoEqual(expected, actual)
+	})
+})

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -273,6 +273,14 @@ var _ = Describe("e2e", func() {
 			printGrpcError(err)
 			Expect(err).NotTo(HaveOccurred(), "commit chaincode")
 
+			result, err := chaincode.QueryCommitted(specCtx, peerConnections[0].connection, peerConnections[0].id, channelName)
+			Expect(err).NotTo(HaveOccurred(), "query committed chaincode")
+
+			committedChaincodes := result.GetChaincodeDefinitions()
+			Expect(committedChaincodes).To(HaveLen(1), "number of committed chaincodes")
+			Expect(committedChaincodes[0].GetName()).To(Equal("basic"), "committed chaincode name")
+			Expect(committedChaincodes[0].GetSequence()).To(Equal(1), "committed chaincode sequence")
+
 			f, _ := os.Create("PackageID")
 			_, err = io.WriteString(f, packageID)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -279,7 +279,7 @@ var _ = Describe("e2e", func() {
 			committedChaincodes := result.GetChaincodeDefinitions()
 			Expect(committedChaincodes).To(HaveLen(1), "number of committed chaincodes")
 			Expect(committedChaincodes[0].GetName()).To(Equal("basic"), "committed chaincode name")
-			Expect(committedChaincodes[0].GetSequence()).To(Equal(1), "committed chaincode sequence")
+			Expect(committedChaincodes[0].GetSequence()).To(Equal(int64(1)), "committed chaincode sequence")
 
 			f, _ := os.Create("PackageID")
 			_, err = io.WriteString(f, packageID)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -273,7 +273,7 @@ var _ = Describe("e2e", func() {
 			printGrpcError(err)
 			Expect(err).NotTo(HaveOccurred(), "commit chaincode")
 
-			result, err := chaincode.QueryCommitted(specCtx, peerConnections[0].connection, peerConnections[0].id, channelName)
+			result, err := chaincode.QueryCommitted(specCtx, n_conn1, org1MSP, channelName)
 			Expect(err).NotTo(HaveOccurred(), "query committed chaincode")
 
 			committedChaincodes := result.GetChaincodeDefinitions()


### PR DESCRIPTION
- Implement query committed function
- Implement query committed unit test
- Add query committed to e2e test

Signed-off-by: Samuel Venzi <samuel.venzi@me.com>
