### PR TITLE
Implement query committed chaincode with name in channel

### DIFF
--- a/pkg/chaincode/lifecycle.go
+++ b/pkg/chaincode/lifecycle.go
@@ -8,13 +8,14 @@ package chaincode
 import "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 
 const (
-	lifecycleChaincodeName              = "_lifecycle"
-	approveTransactionName              = "ApproveChaincodeDefinitionForMyOrg"
-	commitTransactionName               = "CommitChaincodeDefinition"
-	queryInstalledTransactionName       = "QueryInstalledChaincodes"
-	queryCommittedTransactionName       = "QueryChaincodeDefinitions"
-	checkCommitReadinessTransactionName = "CheckCommitReadiness"
-	installTransactionName              = "InstallChaincode"
+	lifecycleChaincodeName                = "_lifecycle"
+	approveTransactionName                = "ApproveChaincodeDefinitionForMyOrg"
+	commitTransactionName                 = "CommitChaincodeDefinition"
+	queryInstalledTransactionName         = "QueryInstalledChaincodes"
+	queryCommittedTransactionName         = "QueryChaincodeDefinitions"
+	queryCommittedWithNameTransactionName = "QueryChaincodeDefinition"
+	checkCommitReadinessTransactionName   = "CheckCommitReadiness"
+	installTransactionName                = "InstallChaincode"
 	// MetadataFile is the expected location of the metadata json document
 	// in the top level of the chaincode package.
 	MetadataFile = "metadata.json"

--- a/pkg/chaincode/querycommittedwithname.go
+++ b/pkg/chaincode/querycommittedwithname.go
@@ -1,0 +1,59 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hyperledger/fabric-admin-sdk/pkg/identity"
+	"github.com/hyperledger/fabric-admin-sdk/pkg/internal/proposal"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// QueryCommittedWithName gets the chaincode definition for the given chaincode name in the given channel
+// with a specific signing identity
+func QueryCommittedWithName(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, channelID, chaincodeName string) (*lifecycle.QueryChaincodeDefinitionResult, error) {
+	queryArgs := &lifecycle.QueryChaincodeDefinitionArgs{
+		Name: chaincodeName,
+	}
+	queryArgsBytes, err := proto.Marshal(queryArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, queryCommittedWithNameTransactionName, proposal.WithArguments(queryArgsBytes), proposal.WithChannel(channelID))
+	if err != nil {
+		return nil, err
+	}
+
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
+	if err != nil {
+		return nil, err
+	}
+
+	endorser := peer.NewEndorserClient(connection)
+
+	proposalResponse, err := endorser.ProcessProposal(ctx, signedProposal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query committed chaincode: %w", err)
+	}
+
+	if err = proposal.CheckSuccessfulResponse(proposalResponse); err != nil {
+		return nil, err
+	}
+
+	result := &lifecycle.QueryChaincodeDefinitionResult{}
+	if err = proto.Unmarshal(proposalResponse.GetResponse().GetPayload(), result); err != nil {
+		return nil, fmt.Errorf("failed to deserialize query committed chaincode result: %w", err)
+	}
+
+	return result, nil
+}

--- a/pkg/chaincode/querycommittedwithname_test.go
+++ b/pkg/chaincode/querycommittedwithname_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("QueryCommittedWithName", func() {
+	It("Endorser client called with supplied context", func(specCtx SpecContext) {
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				return ctx.Err()
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		ctx, cancel := context.WithCancel(specCtx)
+		cancel()
+
+		_, err := QueryCommittedWithName(ctx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+
+		Expect(err).To(MatchError(context.Canceled))
+	})
+
+	It("Endorser client errors returned", func(specCtx SpecContext) {
+		expectedErr := errors.New("EXPECTED_ERROR")
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(expectedErr)
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+
+		Expect(err).To(MatchError(expectedErr))
+	})
+
+	It("Unsuccessful proposal response gives error", func(specCtx SpecContext) {
+		expectedStatus := common.Status_BAD_REQUEST
+		expectedMessage := "EXPECTED_ERROR"
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(And(
+			ContainSubstring("%d", expectedStatus),
+			ContainSubstring(expectedStatus.String()),
+			ContainSubstring(expectedMessage),
+		))
+	})
+
+	It("Uses signer", func(specCtx SpecContext) {
+		expected := []byte("SIGNATURE")
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var signedProposal *peer.SignedProposal
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			}).
+			Times(1)
+
+		mockSigner := NewMockSigner(controller, "", nil, expected)
+
+		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+		Expect(err).NotTo(HaveOccurred())
+
+		actual := signedProposal.GetSignature()
+		Expect(actual).To(BeEquivalentTo(expected))
+	})
+
+	It("Proposal includes creator", func(specCtx SpecContext) {
+		expected := &msp.SerializedIdentity{
+			Mspid:   "MSP_ID",
+			IdBytes: []byte("CREDENTIALS"),
+		}
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var signedProposal *peer.SignedProposal
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			}).
+			Times(1)
+
+		mockSigner := NewMockSigner(controller, expected.Mspid, expected.IdBytes, nil)
+
+		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+		Expect(err).NotTo(HaveOccurred())
+
+		signatureHeader := AssertUnmarshalSignatureHeader(signedProposal)
+
+		actual := &msp.SerializedIdentity{}
+		AssertUnmarshal(signatureHeader.GetCreator(), actual)
+
+		AssertProtoEqual(expected, actual)
+	})
+
+	It("Committed chaincodes returned on successful proposal response", func(specCtx SpecContext) {
+		expected := &lifecycle.QueryChaincodeDefinitionResult{
+			Version:             "CHAINCODE_VERSION",
+			Sequence:            1,
+			EndorsementPlugin:   "ENDORSEMENT_PLUGIN",
+			ValidationPlugin:    "VALIDATION_PLUGIN",
+			ValidationParameter: []byte("VALIDATION_PARAMETER"),
+			Collections:         &peer.CollectionConfigPackage{},
+			InitRequired:        true,
+			Approvals:           map[string]bool{"ORG1": true, "ORG2": true},
+		}
+		response := NewProposalResponse(common.Status_SUCCESS, "")
+		response.Response.Payload = AssertMarshal(expected)
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(response, out)
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		actual, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+		Expect(err).NotTo(HaveOccurred())
+
+		AssertProtoEqual(expected, actual)
+	})
+})

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -274,12 +274,18 @@ var _ = Describe("e2e", func() {
 			Expect(err).NotTo(HaveOccurred(), "commit chaincode")
 
 			result, err := chaincode.QueryCommitted(specCtx, n_conn1, org1MSP, channelName)
-			Expect(err).NotTo(HaveOccurred(), "query committed chaincode")
+			Expect(err).NotTo(HaveOccurred(), "query all committed chaincodes")
 
 			committedChaincodes := result.GetChaincodeDefinitions()
 			Expect(committedChaincodes).To(HaveLen(1), "number of committed chaincodes")
 			Expect(committedChaincodes[0].GetName()).To(Equal("basic"), "committed chaincode name")
 			Expect(committedChaincodes[0].GetSequence()).To(Equal(int64(1)), "committed chaincode sequence")
+
+			resultWithName, err := chaincode.QueryCommittedWithName(specCtx, n_conn1, org1MSP, channelName, Definition.Name)
+			Expect(err).NotTo(HaveOccurred(), "query committed chaincode with name")
+
+			Expect(resultWithName.GetApprovals()).To(Equal(map[string]bool{"Org1MSP": true, "Org2MSP": true}), "committed chaincode approvals")
+			Expect(resultWithName.GetSequence()).To(Equal(int64(1)), "committed chaincode sequence")
 
 			f, _ := os.Create("PackageID")
 			_, err = io.WriteString(f, packageID)


### PR DESCRIPTION
- Implement query committed with name function
- Implement query committed with name unit test
- Add query committed with name to e2e test

Signed-off-by: Samuel Venzi <samuel.venzi@me.com>
