### PR TITLE
Refactor query committed functions to use gateway

### DIFF
--- a/pkg/chaincode/approve_test.go
+++ b/pkg/chaincode/approve_test.go
@@ -21,6 +21,7 @@ import (
 
 const gatewayEndorseMethod = "/gateway.Gateway/Endorse"
 const gatewaySubmitMethod = "/gateway.Gateway/Submit"
+const gatewayEvaluateMethod = "/gateway.Gateway/Evaluate"
 const gatewayCommitStatusMethod = "/gateway.Gateway/CommitStatus"
 
 func NewEndorseResponse(channelName string, result string) *gateway.EndorseResponse {
@@ -50,6 +51,14 @@ func NewEndorseResponse(channelName string, result string) *gateway.EndorseRespo
 					},
 				}),
 			}),
+		},
+	}
+}
+
+func NewEvaluateResponse(channelName string, result string) *gateway.EvaluateResponse {
+	return &gateway.EvaluateResponse{
+		Result: &peer.Response{
+			Payload: []byte(result),
 		},
 	}
 }

--- a/pkg/chaincode/querycommitted_test.go
+++ b/pkg/chaincode/querycommitted_test.go
@@ -10,9 +10,7 @@ import (
 	"errors"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hyperledger/fabric-protos-go-apiv2/common"
-	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
-	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/gateway"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,16 +18,24 @@ import (
 )
 
 var _ = Describe("QueryCommitted", func() {
-	It("Endorser client called with supplied context", func(specCtx SpecContext) {
+	var channelName string
+
+	BeforeEach(func() {
+		channelName = "mockchannel"
+	})
+
+	It("gRPC calls made with supplied context", func(specCtx SpecContext) {
 		controller := gomock.NewController(GinkgoT())
 		defer controller.Finish()
 
+		var evaluateCtxErr error
+
 		mockConnection := NewMockClientConnInterface(controller)
 		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
-				return ctx.Err()
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
+				evaluateCtxErr = ctx.Err()
+				CopyProto(NewEvaluateResponse(channelName, ""), out)
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -37,12 +43,12 @@ var _ = Describe("QueryCommitted", func() {
 		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 
-		_, err := QueryCommitted(ctx, mockConnection, mockSigner, "")
+		_, _ = QueryCommitted(ctx, mockConnection, mockSigner, channelName)
 
-		Expect(err).To(MatchError(context.Canceled))
+		Expect(evaluateCtxErr).To(BeIdenticalTo(context.Canceled), "endorse context error")
 	})
 
-	It("Endorser client errors returned", func(specCtx SpecContext) {
+	It("Endorse errors returned", func(specCtx SpecContext) {
 		expectedErr := errors.New("EXPECTED_ERROR")
 
 		controller := gomock.NewController(GinkgoT())
@@ -50,132 +56,42 @@ var _ = Describe("QueryCommitted", func() {
 
 		mockConnection := NewMockClientConnInterface(controller)
 		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(expectedErr)
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
 
-		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
+		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, channelName)
 
 		Expect(err).To(MatchError(expectedErr))
 	})
 
-	It("Unsuccessful proposal response gives error", func(specCtx SpecContext) {
-		expectedStatus := common.Status_BAD_REQUEST
-		expectedMessage := "EXPECTED_ERROR"
-
+	It("Proposal content", func(specCtx SpecContext) {
 		controller := gomock.NewController(GinkgoT())
 		defer controller.Finish()
 
+		expected := &lifecycle.QueryChaincodeDefinitionsArgs{}
+
+		var evaluateRequest *gateway.EvaluateRequest
 		mockConnection := NewMockClientConnInterface(controller)
 		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
-			})
-
-		mockSigner := NewMockSigner(controller, "", nil, nil)
-
-		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
-
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(And(
-			ContainSubstring("%d", expectedStatus),
-			ContainSubstring(expectedStatus.String()),
-			ContainSubstring(expectedMessage),
-		))
-	})
-
-	It("Uses signer", func(specCtx SpecContext) {
-		expected := []byte("SIGNATURE")
-
-		controller := gomock.NewController(GinkgoT())
-		defer controller.Finish()
-
-		var signedProposal *peer.SignedProposal
-		mockConnection := NewMockClientConnInterface(controller)
-		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
+				evaluateRequest = in
+				CopyProto(NewEvaluateResponse(channelName, ""), out)
 			}).
 			Times(1)
-
-		mockSigner := NewMockSigner(controller, "", nil, expected)
-
-		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
-		Expect(err).NotTo(HaveOccurred())
-
-		actual := signedProposal.GetSignature()
-		Expect(actual).To(BeEquivalentTo(expected))
-	})
-
-	It("Proposal includes creator", func(specCtx SpecContext) {
-		expected := &msp.SerializedIdentity{
-			Mspid:   "MSP_ID",
-			IdBytes: []byte("CREDENTIALS"),
-		}
-
-		controller := gomock.NewController(GinkgoT())
-		defer controller.Finish()
-
-		var signedProposal *peer.SignedProposal
-		mockConnection := NewMockClientConnInterface(controller)
-		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
-			}).
-			Times(1)
-
-		mockSigner := NewMockSigner(controller, expected.Mspid, expected.IdBytes, nil)
-
-		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
-		Expect(err).NotTo(HaveOccurred())
-
-		signatureHeader := AssertUnmarshalSignatureHeader(signedProposal)
-
-		actual := &msp.SerializedIdentity{}
-		AssertUnmarshal(signatureHeader.GetCreator(), actual)
-
-		AssertProtoEqual(expected, actual)
-	})
-
-	It("Committed chaincodes returned on successful proposal response", func(specCtx SpecContext) {
-		expected := &lifecycle.QueryChaincodeDefinitionsResult{
-			ChaincodeDefinitions: []*lifecycle.QueryChaincodeDefinitionsResult_ChaincodeDefinition{
-				{
-					Name:                "CHAINCODE_NAME",
-					Version:             "CHAINCODE_VERSION",
-					Sequence:            1,
-					EndorsementPlugin:   "ENDORSEMENT_PLUGIN",
-					ValidationPlugin:    "VALIDATION_PLUGIN",
-					ValidationParameter: []byte("VALIDATION_PARAMETER"),
-					InitRequired:        true,
-					Collections:         &peer.CollectionConfigPackage{},
-				},
-			},
-		}
-
-		response := NewProposalResponse(common.Status_SUCCESS, "")
-		response.Response.Payload = AssertMarshal(expected)
-
-		controller := gomock.NewController(GinkgoT())
-		defer controller.Finish()
-
-		mockConnection := NewMockClientConnInterface(controller)
-		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(response, out)
-			})
-
 		mockSigner := NewMockSigner(controller, "", nil, nil)
 
-		actual, err := QueryCommitted(specCtx, mockConnection, mockSigner, "mockchannel")
+		_, err := QueryCommitted(specCtx, mockConnection, mockSigner, channelName)
 		Expect(err).NotTo(HaveOccurred())
+
+		invocationSpec := AssertUnmarshalInvocationSpec(evaluateRequest.GetProposedTransaction())
+		args := invocationSpec.GetChaincodeSpec().GetInput().GetArgs()
+		Expect(args).To(HaveLen(2), "number of arguments")
+
+		actual := &lifecycle.QueryChaincodeDefinitionsArgs{}
+		AssertUnmarshal(args[1], actual)
 
 		AssertProtoEqual(expected, actual)
 	})

--- a/pkg/chaincode/querycommittedwithname_test.go
+++ b/pkg/chaincode/querycommittedwithname_test.go
@@ -10,9 +10,7 @@ import (
 	"errors"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hyperledger/fabric-protos-go-apiv2/common"
-	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
-	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/gateway"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,16 +18,26 @@ import (
 )
 
 var _ = Describe("QueryCommittedWithName", func() {
-	It("Endorser client called with supplied context", func(specCtx SpecContext) {
+	var channelName string
+	var chaincodeName string
+
+	BeforeEach(func() {
+		channelName = "mockchannel"
+		chaincodeName = "mockchaincode"
+	})
+
+	It("gRPC calls made with supplied context", func(specCtx SpecContext) {
 		controller := gomock.NewController(GinkgoT())
 		defer controller.Finish()
 
+		var evaluateCtxErr error
+
 		mockConnection := NewMockClientConnInterface(controller)
 		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
-				return ctx.Err()
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
+				evaluateCtxErr = ctx.Err()
+				CopyProto(NewEvaluateResponse(channelName, ""), out)
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -37,12 +45,12 @@ var _ = Describe("QueryCommittedWithName", func() {
 		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 
-		_, err := QueryCommittedWithName(ctx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+		_, _ = QueryCommittedWithName(ctx, mockConnection, mockSigner, channelName, chaincodeName)
 
-		Expect(err).To(MatchError(context.Canceled))
+		Expect(evaluateCtxErr).To(BeIdenticalTo(context.Canceled), "endorse context error")
 	})
 
-	It("Endorser client errors returned", func(specCtx SpecContext) {
+	It("Endorse errors returned", func(specCtx SpecContext) {
 		expectedErr := errors.New("EXPECTED_ERROR")
 
 		controller := gomock.NewController(GinkgoT())
@@ -50,127 +58,44 @@ var _ = Describe("QueryCommittedWithName", func() {
 
 		mockConnection := NewMockClientConnInterface(controller)
 		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(expectedErr)
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
 
-		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, channelName, chaincodeName)
 
 		Expect(err).To(MatchError(expectedErr))
 	})
 
-	It("Unsuccessful proposal response gives error", func(specCtx SpecContext) {
-		expectedStatus := common.Status_BAD_REQUEST
-		expectedMessage := "EXPECTED_ERROR"
-
+	It("Proposal content", func(specCtx SpecContext) {
 		controller := gomock.NewController(GinkgoT())
 		defer controller.Finish()
 
-		mockConnection := NewMockClientConnInterface(controller)
-		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
-			})
-
-		mockSigner := NewMockSigner(controller, "", nil, nil)
-
-		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
-
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(And(
-			ContainSubstring("%d", expectedStatus),
-			ContainSubstring(expectedStatus.String()),
-			ContainSubstring(expectedMessage),
-		))
-	})
-
-	It("Uses signer", func(specCtx SpecContext) {
-		expected := []byte("SIGNATURE")
-
-		controller := gomock.NewController(GinkgoT())
-		defer controller.Finish()
-
-		var signedProposal *peer.SignedProposal
-		mockConnection := NewMockClientConnInterface(controller)
-		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
-			}).
-			Times(1)
-
-		mockSigner := NewMockSigner(controller, "", nil, expected)
-
-		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
-		Expect(err).NotTo(HaveOccurred())
-
-		actual := signedProposal.GetSignature()
-		Expect(actual).To(BeEquivalentTo(expected))
-	})
-
-	It("Proposal includes creator", func(specCtx SpecContext) {
-		expected := &msp.SerializedIdentity{
-			Mspid:   "MSP_ID",
-			IdBytes: []byte("CREDENTIALS"),
+		expected := &lifecycle.QueryChaincodeDefinitionArgs{
+			Name: chaincodeName,
 		}
 
-		controller := gomock.NewController(GinkgoT())
-		defer controller.Finish()
-
-		var signedProposal *peer.SignedProposal
+		var evaluateRequest *gateway.EvaluateRequest
 		mockConnection := NewMockClientConnInterface(controller)
 		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
+				evaluateRequest = in
+				CopyProto(NewEvaluateResponse(channelName, ""), out)
 			}).
 			Times(1)
-
-		mockSigner := NewMockSigner(controller, expected.Mspid, expected.IdBytes, nil)
-
-		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
-		Expect(err).NotTo(HaveOccurred())
-
-		signatureHeader := AssertUnmarshalSignatureHeader(signedProposal)
-
-		actual := &msp.SerializedIdentity{}
-		AssertUnmarshal(signatureHeader.GetCreator(), actual)
-
-		AssertProtoEqual(expected, actual)
-	})
-
-	It("Committed chaincodes returned on successful proposal response", func(specCtx SpecContext) {
-		expected := &lifecycle.QueryChaincodeDefinitionResult{
-			Version:             "CHAINCODE_VERSION",
-			Sequence:            1,
-			EndorsementPlugin:   "ENDORSEMENT_PLUGIN",
-			ValidationPlugin:    "VALIDATION_PLUGIN",
-			ValidationParameter: []byte("VALIDATION_PARAMETER"),
-			Collections:         &peer.CollectionConfigPackage{},
-			InitRequired:        true,
-			Approvals:           map[string]bool{"ORG1": true, "ORG2": true},
-		}
-		response := NewProposalResponse(common.Status_SUCCESS, "")
-		response.Response.Payload = AssertMarshal(expected)
-
-		controller := gomock.NewController(GinkgoT())
-		defer controller.Finish()
-
-		mockConnection := NewMockClientConnInterface(controller)
-		mockConnection.EXPECT().
-			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(response, out)
-			})
-
 		mockSigner := NewMockSigner(controller, "", nil, nil)
 
-		actual, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, "mockchannel", "mockchaincode")
+		_, err := QueryCommittedWithName(specCtx, mockConnection, mockSigner, channelName, chaincodeName)
 		Expect(err).NotTo(HaveOccurred())
+
+		invocationSpec := AssertUnmarshalInvocationSpec(evaluateRequest.GetProposedTransaction())
+		args := invocationSpec.GetChaincodeSpec().GetInput().GetArgs()
+		Expect(args).To(HaveLen(2), "number of arguments")
+
+		actual := &lifecycle.QueryChaincodeDefinitionArgs{}
+		AssertUnmarshal(args[1], actual)
 
 		AssertProtoEqual(expected, actual)
 	})


### PR DESCRIPTION
- Now query committed functions use the evaluate method of the gateway service, as suggested by @bestbeforetoday in #89 
- Unit tests were re-written
- No changes were necessary to E2E test

Signed-off-by: Samuel Venzi <samuel.venzi@me.com>
