### PR TITLE
Implement GetInstalled chaincode package

### DIFF
--- a/pkg/chaincode/approve.go
+++ b/pkg/chaincode/approve.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Approve a chaincode package to specific peer.
+// Approve a chaincode package for the user's own organization.
 func Approve(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, chaincodeDef *Definition) error {
 	err := chaincodeDef.Validate()
 	if err != nil {

--- a/pkg/chaincode/getinstalled.go
+++ b/pkg/chaincode/getinstalled.go
@@ -1,0 +1,58 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hyperledger/fabric-admin-sdk/pkg/identity"
+	"github.com/hyperledger/fabric-admin-sdk/pkg/internal/proposal"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// GetInstalled chaincode package from a specific peer.
+func GetInstalled(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, packageID string) ([]byte, error) {
+	getInstalledArgs := &lifecycle.GetInstalledChaincodePackageArgs{
+		PackageId: packageID,
+	}
+	getInstalledArgsBytes, err := proto.Marshal(getInstalledArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, queryInstalledTransactionName, proposal.WithArguments(getInstalledArgsBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
+	if err != nil {
+		return nil, err
+	}
+
+	endorser := peer.NewEndorserClient(connection)
+
+	proposalResponse, err := endorser.ProcessProposal(ctx, signedProposal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get installed chaincode: %w", err)
+	}
+
+	if err = proposal.CheckSuccessfulResponse(proposalResponse); err != nil {
+		return nil, err
+	}
+
+	result := &lifecycle.GetInstalledChaincodePackageResult{}
+	if err = proto.Unmarshal(proposalResponse.GetResponse().GetPayload(), result); err != nil {
+		return nil, fmt.Errorf("failed to deserialize get installed chaincode result: %w", err)
+	}
+
+	return result.GetChaincodeInstallPackage(), nil
+}

--- a/pkg/chaincode/getinstalled_test.go
+++ b/pkg/chaincode/getinstalled_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("GetInstalled", func() {
+	It("Endorser client called with supplied context", func(specCtx SpecContext) {
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				return ctx.Err()
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		ctx, cancel := context.WithCancel(specCtx)
+		cancel()
+
+		_, err := GetInstalled(ctx, mockConnection, mockSigner, "PACKAGE_ID")
+
+		Expect(err).To(MatchError(context.Canceled))
+	})
+
+	It("Endorser client errors returned", func(specCtx SpecContext) {
+		expectedErr := errors.New("EXPECTED_ERROR")
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(expectedErr)
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := GetInstalled(specCtx, mockConnection, mockSigner, "PACKAGE_ID")
+
+		Expect(err).To(MatchError(expectedErr))
+	})
+
+	It("Unsuccessful proposal response gives error", func(specCtx SpecContext) {
+		expectedStatus := common.Status_BAD_REQUEST
+		expectedMessage := "EXPECTED_ERROR"
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := GetInstalled(specCtx, mockConnection, mockSigner, "PACKAGE_ID")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(And(
+			ContainSubstring("%d", expectedStatus),
+			ContainSubstring(expectedStatus.String()),
+			ContainSubstring(expectedMessage),
+		))
+	})
+
+	It("Uses signer", func(specCtx SpecContext) {
+		expected := []byte("SIGNATURE")
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var signedProposal *peer.SignedProposal
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			}).
+			Times(1)
+
+		mockSigner := NewMockSigner(controller, "", nil, expected)
+
+		_, err := GetInstalled(specCtx, mockConnection, mockSigner, "PACKAGE_ID")
+		Expect(err).NotTo(HaveOccurred())
+
+		actual := signedProposal.GetSignature()
+		Expect(actual).To(BeEquivalentTo(expected))
+	})
+
+	It("Proposal includes creator", func(specCtx SpecContext) {
+		expected := &msp.SerializedIdentity{
+			Mspid:   "MSP_ID",
+			IdBytes: []byte("CREDENTIALS"),
+		}
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var signedProposal *peer.SignedProposal
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			}).
+			Times(1)
+
+		mockSigner := NewMockSigner(controller, expected.Mspid, expected.IdBytes, nil)
+
+		_, err := GetInstalled(specCtx, mockConnection, mockSigner, "PACKAGE_ID")
+		Expect(err).NotTo(HaveOccurred())
+
+		signatureHeader := AssertUnmarshalSignatureHeader(signedProposal)
+
+		actual := &msp.SerializedIdentity{}
+		AssertUnmarshal(signatureHeader.GetCreator(), actual)
+
+		AssertProtoEqual(expected, actual)
+	})
+
+	It("Proposal includes supplied chaincode package ID", func(specCtx SpecContext) {
+		expected := "PACKAGE_ID"
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var signedProposal *peer.SignedProposal
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			}).
+			Times(1)
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := GetInstalled(specCtx, mockConnection, mockSigner, expected)
+		Expect(err).NotTo(HaveOccurred())
+
+		invocationSpec := AssertUnmarshalInvocationSpec(signedProposal)
+		args := invocationSpec.GetChaincodeSpec().GetInput().GetArgs()
+		Expect(args).To(HaveLen(2), "number of arguments")
+
+		chaincodeArgs := &lifecycle.GetInstalledChaincodePackageArgs{}
+		AssertUnmarshal(args[1], chaincodeArgs)
+
+		actual := chaincodeArgs.GetPackageId()
+		Expect(actual).To(Equal(expected), "chaincode package ID")
+	})
+
+	It("Installed chaincode package returned on successful proposal response", func(specCtx SpecContext) {
+		expected := &lifecycle.GetInstalledChaincodePackageResult{
+			ChaincodeInstallPackage: []byte("CHAINCODE_PACKAGE"),
+		}
+
+		response := NewProposalResponse(common.Status_SUCCESS, "")
+		response.Response.Payload = AssertMarshal(expected)
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(response, out)
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		actual, err := GetInstalled(specCtx, mockConnection, mockSigner, "PACKAGE_ID")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(actual).To(Equal(expected.GetChaincodeInstallPackage()))
+	})
+})

--- a/pkg/chaincode/lifecycle.go
+++ b/pkg/chaincode/lifecycle.go
@@ -20,6 +20,7 @@ const (
 	queryCommittedWithNameTransactionName = "QueryChaincodeDefinition"
 	checkCommitReadinessTransactionName   = "CheckCommitReadiness"
 	installTransactionName                = "InstallChaincode"
+	getInstalledTransactionName           = "GetInstalledChaincodePackage"
 	// MetadataFile is the expected location of the metadata json document
 	// in the top level of the chaincode package.
 	MetadataFile = "metadata.json"

--- a/pkg/chaincode/lifecycle.go
+++ b/pkg/chaincode/lifecycle.go
@@ -16,6 +16,7 @@ const (
 	approveTransactionName                = "ApproveChaincodeDefinitionForMyOrg"
 	commitTransactionName                 = "CommitChaincodeDefinition"
 	queryInstalledTransactionName         = "QueryInstalledChaincodes"
+	queryApprovedTransactionName          = "QueryApprovedChaincodeDefinition"
 	queryCommittedTransactionName         = "QueryChaincodeDefinitions"
 	queryCommittedWithNameTransactionName = "QueryChaincodeDefinition"
 	checkCommitReadinessTransactionName   = "CheckCommitReadiness"

--- a/pkg/chaincode/packageID.go
+++ b/pkg/chaincode/packageID.go
@@ -8,14 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 )
 
-func PackageID(PackageFile string) (string, error) {
-	pkgBytes, err := os.ReadFile(PackageFile)
+func PackageID(packageReader io.Reader) (string, error) {
+	pkgBytes, err := io.ReadAll(packageReader)
 	if err != nil {
-		return "", fmt.Errorf("failed to read chaincode package at '%s' %w", PackageFile, err)
+		return "", fmt.Errorf("failed to read chaincode package: %w", err)
 	}
 	metadata, _, err := ParseChaincodePackage(pkgBytes)
 	if err != nil {

--- a/pkg/chaincode/queryapproved_test.go
+++ b/pkg/chaincode/queryapproved_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hyperledger/fabric-protos-go-apiv2/gateway"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("QueryApproved", func() {
+	var channelName string
+	var chaincodeName string
+	var sequence int64
+
+	BeforeEach(func() {
+		channelName = "mockchannel"
+		chaincodeName = "CHAINCODE_NAME"
+		sequence = 1
+	})
+
+	It("gRPC calls made with supplied context", func(specCtx SpecContext) {
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		var evaluateCtxErr error
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
+				evaluateCtxErr = ctx.Err()
+				CopyProto(NewEvaluateResponse(""), out)
+			})
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		ctx, cancel := context.WithCancel(specCtx)
+		cancel()
+
+		_, _ = QueryApproved(ctx, mockConnection, mockSigner, channelName, chaincodeName, sequence)
+
+		Expect(evaluateCtxErr).To(BeIdenticalTo(context.Canceled), "endorse context error")
+	})
+
+	It("Endorse errors returned", func(specCtx SpecContext) {
+		expectedErr := errors.New("EXPECTED_ERROR")
+
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(expectedErr)
+
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := QueryApproved(specCtx, mockConnection, mockSigner, channelName, chaincodeName, sequence)
+
+		Expect(err).To(MatchError(expectedErr))
+	})
+
+	It("Proposal content", func(specCtx SpecContext) {
+		controller := gomock.NewController(GinkgoT())
+		defer controller.Finish()
+
+		expected := &lifecycle.QueryApprovedChaincodeDefinitionArgs{
+			Name:     chaincodeName,
+			Sequence: sequence,
+		}
+
+		var evaluateRequest *gateway.EvaluateRequest
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
+				evaluateRequest = in
+				CopyProto(NewEvaluateResponse(""), out)
+			}).
+			Times(1)
+		mockSigner := NewMockSigner(controller, "", nil, nil)
+
+		_, err := QueryApproved(specCtx, mockConnection, mockSigner, channelName, chaincodeName, sequence)
+		Expect(err).NotTo(HaveOccurred())
+
+		invocationSpec := AssertUnmarshalInvocationSpec(evaluateRequest.GetProposedTransaction())
+		args := invocationSpec.GetChaincodeSpec().GetInput().GetArgs()
+		Expect(args).To(HaveLen(2), "number of arguments")
+
+		actual := &lifecycle.QueryApprovedChaincodeDefinitionArgs{}
+		AssertUnmarshal(args[1], actual)
+
+		AssertProtoEqual(expected, actual)
+	})
+})

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -269,6 +269,16 @@ var _ = Describe("e2e", func() {
 				Expect(err).NotTo(HaveOccurred(), "approve chaincode for org %s", target.id.MspID())
 			})
 
+			// Query approved chaincode for each org
+			runParallel(peerConnections, func(target *ConnectionDetails) {
+				ctx, cancel := context.WithTimeout(specCtx, 30*time.Second)
+				defer cancel()
+				result, err := chaincode.QueryApproved(ctx, target.connection, target.id, channelName, chaincodeDef.Name, chaincodeDef.Sequence)
+				printGrpcError(err)
+				Expect(err).NotTo(HaveOccurred(), "query approved chaincode for org %s", target.id.MspID())
+				Expect(result.GetVersion()).To(Equal(chaincodeDef.Version))
+			})
+
 			// Check chaincode commit readiness
 			readinessCtx, readinessCancel := context.WithTimeout(specCtx, 30*time.Second)
 			defer readinessCancel()


### PR DESCRIPTION
Contains two commits to be merged as separate commits. One for GetInstalled chaincode package; the other for QueryApproved chaincode definition.

Changed chaincode.PackageID() to take a Reader for consistency with chaincode.Install().

Closes #102
Closes #103