### PR TITLE
Update godoc and examples for chaincode package

### DIFF
--- a/pkg/chaincode/approve.go
+++ b/pkg/chaincode/approve.go
@@ -18,9 +18,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Approve a chaincode package for the user's own organization.
+// Approve a chaincode package for the user's own organization. The connection may be to any Gateway peer that is a
+// member of the channel.
 func Approve(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, chaincodeDef *Definition) error {
-	err := chaincodeDef.Validate()
+	err := chaincodeDef.validate()
 	if err != nil {
 		return err
 	}

--- a/pkg/chaincode/checkcommitreadiness.go
+++ b/pkg/chaincode/checkcommitreadiness.go
@@ -18,8 +18,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// CheckCommitReadiness for a chaincode.
-func CheckCommitReadiness(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, chaincodeDef *Definition) (*lifecycle.CheckCommitReadinessResult, error) {
+// CheckCommitReadiness for a chaincode and return all approval records. The connection may be to any Gateway peer that
+// is a member of the channel.
+func CheckCommitReadiness(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, chaincodeDef *Definition) (*lifecycle.CheckCommitReadinessResult, error) {
 	args := &lifecycle.CheckCommitReadinessArgs{
 		Name:                chaincodeDef.Name,
 		Version:             chaincodeDef.Version,
@@ -35,7 +36,7 @@ func CheckCommitReadiness(ctx context.Context, connection grpc.ClientConnInterfa
 		return nil, err
 	}
 
-	gw, err := gateway.New(connection, signingID)
+	gw, err := gateway.New(connection, id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chaincode/commit.go
+++ b/pkg/chaincode/commit.go
@@ -13,9 +13,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Commit a chaincode package to specific peer.
+// Commit a chaincode definition to the channel. This requires that sufficient organizations have approved the chaincode
+// definition. The connection may be to any Gateway peer that is a member of the channel.
 func Commit(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, chaincodeDef *Definition) error {
-	err := chaincodeDef.Validate()
+	err := chaincodeDef.validate()
 	if err != nil {
 		return err
 	}

--- a/pkg/chaincode/example_test.go
+++ b/pkg/chaincode/example_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"time"
+
+	"github.com/hyperledger/fabric-admin-sdk/pkg/chaincode"
+	"github.com/hyperledger/fabric-admin-sdk/pkg/identity"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+const peerName = "peer.example.org"
+const peerEndpoint = peerName + ":7051"
+const mspID = "Org1"
+const chaincodePackageFile = "basic.tar.gz"
+
+func Example() {
+	// gRPC connection a target peer.
+	connection := newGrpcConnection()
+	defer connection.Close()
+
+	// Client identity used to carry out deployment tasks.
+	id, err := identity.NewPrivateKeySigningIdentity(mspID, readCertificate(), readPrivateKey())
+	panicOnError(err)
+
+	// Context used to manage Fabric invocations.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Read existing chaincode package file.
+	chaincodePackage, err := os.Open(chaincodePackageFile)
+	panicOnError(err)
+
+	// Install chaincode package. This must be performed for each peer on which the chaincode is to be installed.
+	err = chaincode.Install(ctx, connection, id, chaincodePackage)
+	panicOnError(err)
+
+	// Definition of the chaincode as it should appear on the channel.
+	chaincodeDefinition := &chaincode.Definition{
+		ChannelName: "mychannel",
+		Name:        "basic",
+		Version:     "1.0",
+		Sequence:    1,
+	}
+
+	// Approve chaincode definition. This must be performed using client identities from sufficient organizations to
+	// satisfy the approval policy.
+	err = chaincode.Approve(ctx, connection, id, chaincodeDefinition)
+	panicOnError(err)
+
+	// Commit approved chaincode definition. This can be carried out by any organization once enough approvals have
+	// been recorded.
+	err = chaincode.Commit(ctx, connection, id, chaincodeDefinition)
+	panicOnError(err)
+}
+
+func newGrpcConnection() *grpc.ClientConn {
+	caCertificate := readCertificate()
+	certPool := x509.NewCertPool()
+	certPool.AddCert(caCertificate)
+	transportCredentials := credentials.NewClientTLSFromCert(certPool, "")
+
+	connection, err := grpc.Dial(peerEndpoint, grpc.WithTransportCredentials(transportCredentials))
+	panicOnError(err)
+
+	return connection
+}
+
+func readCertificate() *x509.Certificate {
+	certificatePEM, err := os.ReadFile("certificate.pem")
+	panicOnError(err)
+
+	block, _ := pem.Decode([]byte(certificatePEM))
+	if block == nil {
+		panic("failed to parse certificate PEM")
+	}
+	certificate, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		panic("failed to parse certificate: " + err.Error())
+	}
+
+	return certificate
+}
+
+func readPrivateKey() crypto.PrivateKey {
+	privateKeyPEM, err := os.ReadFile("privateKey.pem")
+	panicOnError(err)
+
+	block, _ := pem.Decode(privateKeyPEM)
+	if block == nil {
+		panic("failed to parse private key PEM")
+	}
+
+	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		panic("failed to parse PKCS8 encoded private key: " + err.Error())
+	}
+
+	return privateKey
+}
+
+func panicOnError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/chaincode/getinstalled.go
+++ b/pkg/chaincode/getinstalled.go
@@ -18,8 +18,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// GetInstalled chaincode package from a specific peer.
-func GetInstalled(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, packageID string) ([]byte, error) {
+// GetInstalled chaincode package from a specific peer. The connection must be to the specific peer where the chaincode
+// is installed.
+func GetInstalled(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, packageID string) ([]byte, error) {
 	getInstalledArgs := &lifecycle.GetInstalledChaincodePackageArgs{
 		PackageId: packageID,
 	}
@@ -28,12 +29,12 @@ func GetInstalled(ctx context.Context, connection grpc.ClientConnInterface, sign
 		return nil, err
 	}
 
-	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, queryInstalledTransactionName, proposal.WithArguments(getInstalledArgsBytes))
+	proposalProto, err := proposal.NewProposal(id, lifecycleChaincodeName, queryInstalledTransactionName, proposal.WithArguments(getInstalledArgsBytes))
 	if err != nil {
 		return nil, err
 	}
 
-	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chaincode/install.go
+++ b/pkg/chaincode/install.go
@@ -19,8 +19,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Install a chaincode package to specific peer.
-func Install(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, packageReader io.Reader) error {
+// Install a chaincode package to specific peer. The connection must be to the specific peer where the chaincode is to
+// be installed.
+func Install(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, packageReader io.Reader) error {
 	packageBytes, err := io.ReadAll(packageReader)
 	if err != nil {
 		return fmt.Errorf("failed to read chaincode package: %w", err)
@@ -34,12 +35,12 @@ func Install(ctx context.Context, connection grpc.ClientConnInterface, signingID
 		return err
 	}
 
-	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, installTransactionName, proposal.WithArguments(installArgsBytes))
+	proposalProto, err := proposal.NewProposal(id, lifecycleChaincodeName, installTransactionName, proposal.WithArguments(installArgsBytes))
 	if err != nil {
 		return err
 	}
 
-	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, id)
 	if err != nil {
 		return err
 	}

--- a/pkg/chaincode/lifecycle.go
+++ b/pkg/chaincode/lifecycle.go
@@ -3,6 +3,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+// Package chaincode provides functions for driving chaincode lifecycle.
 package chaincode
 
 import (
@@ -22,30 +23,54 @@ const (
 	checkCommitReadinessTransactionName   = "CheckCommitReadiness"
 	installTransactionName                = "InstallChaincode"
 	getInstalledTransactionName           = "GetInstalledChaincodePackage"
-	// MetadataFile is the expected location of the metadata json document
-	// in the top level of the chaincode package.
-	MetadataFile = "metadata.json"
 
-	// CodePackageFile is the expected location of the code package in the
-	// top level of the chaincode package
-	CodePackageFile = "code.tar.gz"
+	// metadataFile is the expected location of the metadata json document
+	// in the top level of the chaincode package.
+	metadataFile = "metadata.json"
+
+	// codePackageFile is the expected location of the code package in the
+	// top level of the chaincode package.
+	codePackageFile = "code.tar.gz"
 )
 
-// Definition of a chaincode
+// Definition of a chaincode.
 type Definition struct {
-	ChannelName         string
-	PackageID           string
-	Name                string
-	Version             string
-	EndorsementPlugin   string
-	ValidationPlugin    string
-	Sequence            int64
+	// ChannelName on which the chaincode is deployed.
+	ChannelName string
+
+	// PackageID is a unique identifier for a chaincode package, combining the package label with a hash of the package.
+	PackageID string
+
+	// Name used when invoking the chaincode.
+	Name string
+
+	// Version associated with a given chaincode package.
+	Version string
+
+	// EndorsementPlugin used by the chaincode. May be omitted unless a custom plugin is required.
+	EndorsementPlugin string
+
+	// ValidationPlugin used by the chaincode. May be omitted unless a custom plugin is required.
+	ValidationPlugin string
+
+	// Sequence number indicating the number of times the chaincode has been defined on a channel, and used to keep
+	// track of chaincode upgrades.
+	Sequence int64
+
+	// ValidationParameter defines the endorsement policy for the chaincode. This can be an explicit endorsement policy
+	// string or reference a policy in the channel configuration.
 	ValidationParameter []byte
-	InitRequired        bool
-	Collections         *peer.CollectionConfigPackage
+
+	// InitRequired is true only if the chaincode defines an Init function using the low-level shim API, which must be
+	// invoked before other transaction functions may be invoked; otherwise false. It is not recommended to rely on
+	// functionality.
+	InitRequired bool
+
+	// Collections configuration for private data collections accessed by the chaincode.
+	Collections *peer.CollectionConfigPackage
 }
 
-func (d *Definition) Validate() error {
+func (d *Definition) validate() error {
 	if d.ChannelName == "" {
 		return fmt.Errorf("channel name is required for channel approve/commit")
 	}

--- a/pkg/chaincode/lifecycle_test.go
+++ b/pkg/chaincode/lifecycle_test.go
@@ -1,7 +1,6 @@
-package chaincode_test
+package chaincode
 
 import (
-	"github.com/hyperledger/fabric-admin-sdk/pkg/chaincode"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -9,57 +8,57 @@ import (
 var _ = Describe("Lifecycle", func() {
 	Context("Definitions", func() {
 		It("Validate ChannelName", func() {
-			chaincodeDefinition := &chaincode.Definition{}
-			err := chaincodeDefinition.Validate()
+			chaincodeDefinition := &Definition{}
+			err := chaincodeDefinition.validate()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Validate Name", func() {
-			chaincodeDefinition := &chaincode.Definition{
+			chaincodeDefinition := &Definition{
 				ChannelName: "mycc",
 			}
-			err := chaincodeDefinition.Validate()
+			err := chaincodeDefinition.validate()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Validate Version", func() {
-			chaincodeDefinition := &chaincode.Definition{
+			chaincodeDefinition := &Definition{
 				Name:        "CHAINCODE",
 				ChannelName: "mycc",
 			}
-			err := chaincodeDefinition.Validate()
+			err := chaincodeDefinition.validate()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Validate missing / zero Sequence", func() {
-			chaincodeDefinition := &chaincode.Definition{
+			chaincodeDefinition := &Definition{
 				Name:        "CHAINCODE",
 				Version:     "1.0",
 				ChannelName: "mycc",
 			}
-			err := chaincodeDefinition.Validate()
+			err := chaincodeDefinition.validate()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Validate negative Sequence", func() {
-			chaincodeDefinition := &chaincode.Definition{
+			chaincodeDefinition := &Definition{
 				Name:        "CHAINCODE",
 				Version:     "1.0",
 				Sequence:    -1,
 				ChannelName: "mycc",
 			}
-			err := chaincodeDefinition.Validate()
+			err := chaincodeDefinition.validate()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Pass validation", func() {
-			chaincodeDefinition := &chaincode.Definition{
+			chaincodeDefinition := &Definition{
 				Name:        "CHAINCODE",
 				Version:     "1.0",
 				Sequence:    1,
 				ChannelName: "my_cc",
 			}
-			err := chaincodeDefinition.Validate()
+			err := chaincodeDefinition.validate()
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/chaincode/packageID.go
+++ b/pkg/chaincode/packageID.go
@@ -73,14 +73,14 @@ func ParseChaincodePackage(source []byte) (*ChaincodePackageMetadata, []byte, er
 
 		switch header.Name {
 
-		case MetadataFile:
+		case metadataFile:
 			ccPackageMetadata = &ChaincodePackageMetadata{}
 			err := json.Unmarshal(fileBytes, ccPackageMetadata)
 			if err != nil {
-				return ccPackageMetadata, nil, fmt.Errorf("could not unmarshal %s as json %w", MetadataFile, err)
+				return ccPackageMetadata, nil, fmt.Errorf("could not unmarshal %s as json %w", metadataFile, err)
 			}
 
-		case CodePackageFile:
+		case codePackageFile:
 			codePackage = fileBytes
 		default:
 			fmt.Println("Encountered unexpected file " + header.Name + " in top level of chaincode package")
@@ -92,7 +92,7 @@ func ParseChaincodePackage(source []byte) (*ChaincodePackageMetadata, []byte, er
 	}
 
 	if ccPackageMetadata == nil {
-		return ccPackageMetadata, nil, fmt.Errorf("did not find any package metadata (missing %s)", MetadataFile)
+		return ccPackageMetadata, nil, fmt.Errorf("did not find any package metadata (missing %s)", metadataFile)
 	}
 
 	if err := ValidateLabel(ccPackageMetadata.Label); err != nil {

--- a/pkg/chaincode/queryapproved.go
+++ b/pkg/chaincode/queryapproved.go
@@ -18,7 +18,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// QueryApproved chaincode definition for the user's own organization.
+// QueryApproved chaincode definition for the user's own organization. The connection may be to any Gateway peer that is
+// a member of the channel.
 func QueryApproved(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, channelID string, chaincodeName string, sequence int64) (*lifecycle.QueryApprovedChaincodeDefinitionResult, error) {
 	queryArgs := &lifecycle.QueryApprovedChaincodeDefinitionArgs{
 		Name:     chaincodeName,

--- a/pkg/chaincode/querycommitted.go
+++ b/pkg/chaincode/querycommitted.go
@@ -18,15 +18,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// QueryCommitted chaincode.
-func QueryCommitted(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, channelID string) (*lifecycle.QueryChaincodeDefinitionsResult, error) {
+// QueryCommitted returns the definitions of all committed chaincode for a given channel. The connection may be to any
+// Gateway peer that is a member of the channel.
+func QueryCommitted(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, channelID string) (*lifecycle.QueryChaincodeDefinitionsResult, error) {
 	queryArgs := &lifecycle.QueryChaincodeDefinitionsArgs{}
 	queryArgsBytes, err := proto.Marshal(queryArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	gw, err := gateway.New(connection, signingID)
+	gw, err := gateway.New(connection, id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chaincode/querycommittedwithname.go
+++ b/pkg/chaincode/querycommittedwithname.go
@@ -18,9 +18,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// QueryCommittedWithName gets the chaincode definition for the given chaincode name in the given channel
-// with a specific signing identity
-func QueryCommittedWithName(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, channelID, chaincodeName string) (*lifecycle.QueryChaincodeDefinitionResult, error) {
+// QueryCommittedWithName returns the definition of the named chaincode for a given channel. The connection may be to
+// any Gateway peer that is a member of the channel.
+func QueryCommittedWithName(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, channelID, chaincodeName string) (*lifecycle.QueryChaincodeDefinitionResult, error) {
 	queryArgs := &lifecycle.QueryChaincodeDefinitionArgs{
 		Name: chaincodeName,
 	}
@@ -29,7 +29,7 @@ func QueryCommittedWithName(ctx context.Context, connection grpc.ClientConnInter
 		return nil, err
 	}
 
-	gw, err := gateway.New(connection, signingID)
+	gw, err := gateway.New(connection, id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chaincode/queryinstalled.go
+++ b/pkg/chaincode/queryinstalled.go
@@ -18,20 +18,21 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// QueryInstalled chaincode on a specific peer.
-func QueryInstalled(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity) (*lifecycle.QueryInstalledChaincodesResult, error) {
+// QueryInstalled chaincode on a specific peer. The connection must be to the specific peer where the chaincode is
+// installed.
+func QueryInstalled(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity) (*lifecycle.QueryInstalledChaincodesResult, error) {
 	queryArgs := &lifecycle.QueryInstalledChaincodesArgs{}
 	queryArgsBytes, err := proto.Marshal(queryArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, queryInstalledTransactionName, proposal.WithArguments(queryArgsBytes))
+	proposalProto, err := proposal.NewProposal(id, lifecycleChaincodeName, queryInstalledTransactionName, proposal.WithArguments(queryArgsBytes))
 	if err != nil {
 		return nil, err
 	}
 
-	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Made the Definition.validat() function private since it is not used outside of the package.