### PR TITLE
Return result on chaincode install

### DIFF
--- a/pkg/chaincode/example_test.go
+++ b/pkg/chaincode/example_test.go
@@ -43,7 +43,7 @@ func Example() {
 	panicOnError(err)
 
 	// Install chaincode package. This must be performed for each peer on which the chaincode is to be installed.
-	err = chaincode.Install(ctx, connection, id, chaincodePackage)
+	_, err = chaincode.Install(ctx, connection, id, chaincodePackage)
 	panicOnError(err)
 
 	// Definition of the chaincode as it should appear on the channel.

--- a/pkg/chaincode/getinstalled_test.go
+++ b/pkg/chaincode/getinstalled_test.go
@@ -28,7 +28,7 @@ var _ = Describe("GetInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				CopyProto(NewSuccessfulProposalResponse(nil), out)
 				return ctx.Err()
 			})
 
@@ -71,7 +71,7 @@ var _ = Describe("GetInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
+				CopyProto(NewErrorProposalResponse(expectedStatus, expectedMessage), out)
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -98,7 +98,7 @@ var _ = Describe("GetInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				CopyProto(NewSuccessfulProposalResponse(nil), out)
 			}).
 			Times(1)
 
@@ -126,7 +126,7 @@ var _ = Describe("GetInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				CopyProto(NewSuccessfulProposalResponse(nil), out)
 			}).
 			Times(1)
 
@@ -155,7 +155,7 @@ var _ = Describe("GetInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				CopyProto(NewSuccessfulProposalResponse(nil), out)
 			}).
 			Times(1)
 
@@ -180,8 +180,7 @@ var _ = Describe("GetInstalled", func() {
 			ChaincodeInstallPackage: []byte("CHAINCODE_PACKAGE"),
 		}
 
-		response := NewProposalResponse(common.Status_SUCCESS, "")
-		response.Response.Payload = AssertMarshal(expected)
+		response := NewSuccessfulProposalResponse(AssertMarshal(expected))
 
 		controller := gomock.NewController(GinkgoT())
 		defer controller.Finish()

--- a/pkg/chaincode/install.go
+++ b/pkg/chaincode/install.go
@@ -21,10 +21,10 @@ import (
 
 // Install a chaincode package to specific peer. The connection must be to the specific peer where the chaincode is to
 // be installed.
-func Install(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, packageReader io.Reader) error {
+func Install(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, packageReader io.Reader) (*lifecycle.InstallChaincodeResult, error) {
 	packageBytes, err := io.ReadAll(packageReader)
 	if err != nil {
-		return fmt.Errorf("failed to read chaincode package: %w", err)
+		return nil, fmt.Errorf("failed to read chaincode package: %w", err)
 	}
 
 	installArgs := &lifecycle.InstallChaincodeArgs{
@@ -32,25 +32,34 @@ func Install(ctx context.Context, connection grpc.ClientConnInterface, id identi
 	}
 	installArgsBytes, err := proto.Marshal(installArgs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	proposalProto, err := proposal.NewProposal(id, lifecycleChaincodeName, installTransactionName, proposal.WithArguments(installArgsBytes))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	signedProposal, err := proposal.NewSignedProposal(proposalProto, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	endorser := peer.NewEndorserClient(connection)
 
 	proposalResponse, err := endorser.ProcessProposal(ctx, signedProposal)
 	if err != nil {
-		return fmt.Errorf("failed to install chaincode: %w", err)
+		return nil, fmt.Errorf("failed to install chaincode: %w", err)
 	}
 
-	return proposal.CheckSuccessfulResponse(proposalResponse)
+	if err := proposal.CheckSuccessfulResponse(proposalResponse); err != nil {
+		return nil, err
+	}
+
+	result := &lifecycle.InstallChaincodeResult{}
+	if err := proto.Unmarshal(proposalResponse.GetResponse().GetPayload(), result); err != nil {
+		return nil, fmt.Errorf("failed to deserialize install chaincode result: %w", err)
+	}
+
+	return result, nil
 }

--- a/pkg/chaincode/queryinstalled_test.go
+++ b/pkg/chaincode/queryinstalled_test.go
@@ -40,7 +40,7 @@ var _ = Describe("QueryInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				CopyProto(NewSuccessfulProposalResponse(nil), out)
 				return ctx.Err()
 			})
 
@@ -83,7 +83,7 @@ var _ = Describe("QueryInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
+				CopyProto(NewErrorProposalResponse(expectedStatus, expectedMessage), out)
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -110,7 +110,7 @@ var _ = Describe("QueryInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				CopyProto(NewSuccessfulProposalResponse(nil), out)
 			}).
 			Times(1)
 
@@ -138,7 +138,7 @@ var _ = Describe("QueryInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+				CopyProto(NewSuccessfulProposalResponse(nil), out)
 			}).
 			Times(1)
 
@@ -165,8 +165,7 @@ var _ = Describe("QueryInstalled", func() {
 			},
 		}
 
-		response := NewProposalResponse(common.Status_SUCCESS, "")
-		response.Response.Payload = AssertMarshal(expected)
+		response := NewSuccessfulProposalResponse(AssertMarshal(expected))
 
 		controller := gomock.NewController(GinkgoT())
 		defer controller.Finish()

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -53,7 +53,7 @@ func JoinChannel(block *cb.Block, id identity.SigningIdentity, connection pb.End
 		return err
 	}
 
-	if err = proposal.CheckSuccessfulResponse(proposalResp); err != nil {
+	if err := proposal.CheckSuccessfulResponse(proposalResp); err != nil {
 		return err
 	}
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -232,9 +232,11 @@ var _ = Describe("e2e", func() {
 			runParallel(peerConnections, func(target *ConnectionDetails) {
 				ctx, cancel := context.WithTimeout(specCtx, 2*time.Minute)
 				defer cancel()
-				err = chaincode.Install(ctx, target.connection, target.id, bytes.NewReader(chaincodePackage))
+				result, err := chaincode.Install(ctx, target.connection, target.id, bytes.NewReader(chaincodePackage))
 				printGrpcError(err)
 				Expect(err).NotTo(HaveOccurred(), "chaincode install")
+				Expect(result.GetPackageId()).To(Equal(packageID), "install chaincode package ID")
+				Expect(result.GetLabel()).To(Equal(dummyMeta.Label), "install chaincode label")
 			})
 
 			// Query installed chaincode on each peer


### PR DESCRIPTION
The chaincode install result includes the package ID and label for the install, which may avoid work required by the client (such as computing the package ID) in order to perform later steps in the chaincode lifecycle.