### PR TITLE
Update channel API for consistency with chaincode API

### DIFF
--- a/test/channel_test.go
+++ b/test/channel_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hyperledger/fabric-admin-sdk/internal/network"
 	"github.com/hyperledger/fabric-admin-sdk/pkg/channel"
 
-	npb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -46,7 +45,7 @@ var _ = Describe("channel", func() {
 	})
 
 	Context("get config block", func() {
-		It("should work", func() {
+		It("should work", func(specCtx SpecContext) {
 			_, err := os.Stat("../fabric-samples/test-network")
 			if err != nil {
 				Skip("skip for unit test")
@@ -66,19 +65,18 @@ var _ = Describe("channel", func() {
 			Expect(err).NotTo(HaveOccurred())
 			peerConnection, err := network.DialConnection(peer1)
 			Expect(err).NotTo(HaveOccurred())
-			endorser := npb.NewEndorserClient(peerConnection)
 
 			id, err := CreateSigner(PrivKeyPath, SignCert, MSPID)
 			Expect(err).NotTo(HaveOccurred())
 
-			configBlock, err := channel.GetConfigBlock(id, channelID, endorser)
+			configBlock, err := channel.GetConfigBlock(specCtx, peerConnection, id, channelID)
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println("config block", configBlock)
 		})
 	})
 
 	Context("get block chain info", func() {
-		It("should work", func() {
+		It("should work", func(specCtx SpecContext) {
 			_, err := os.Stat("../fabric-samples/test-network")
 			if err != nil {
 				Skip("skip for unit test")
@@ -98,12 +96,11 @@ var _ = Describe("channel", func() {
 			Expect(err).NotTo(HaveOccurred())
 			peerConnection, err := network.DialConnection(peer1)
 			Expect(err).NotTo(HaveOccurred())
-			endorser := npb.NewEndorserClient(peerConnection)
 
 			id, err := CreateSigner(PrivKeyPath, SignCert, MSPID)
 			Expect(err).NotTo(HaveOccurred())
 
-			blockChainInfo, err := channel.GetBlockChainInfo(id, channelID, endorser)
+			blockChainInfo, err := channel.GetBlockChainInfo(specCtx, peerConnection, id, channelID)
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println("blockchain info", blockChainInfo)
 		})

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 	gatewaypb "github.com/hyperledger/fabric-protos-go-apiv2/gateway"
 
-	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
@@ -117,9 +116,6 @@ var _ = Describe("e2e", func() {
 			Expect(err).NotTo(HaveOccurred())
 			peer1Connection, err := network.DialConnection(peer1)
 			Expect(err).NotTo(HaveOccurred())
-
-			peer1Endorser := peer.NewEndorserClient(peer1Connection)
-			Expect(err).NotTo(HaveOccurred())
 			org1MSP, err := CreateSigner(PrivKeyPath, SignCert, org1MspID)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -135,10 +131,9 @@ var _ = Describe("e2e", func() {
 			Expect(err).NotTo(HaveOccurred())
 			peer2Connection, err := network.DialConnection(peer2)
 			Expect(err).NotTo(HaveOccurred())
-			peer2Endorser := peer.NewEndorserClient(peer2Connection)
-			Expect(err).NotTo(HaveOccurred())
 			org2MSP, err := CreateSigner(PrivKeyPath, SignCert, org2MspID)
 			Expect(err).NotTo(HaveOccurred())
+
 			//genesis block
 			createChannel, ok := os.LookupEnv("createChannel")
 			if createChannel == "true" && ok {
@@ -182,15 +177,11 @@ var _ = Describe("e2e", func() {
 				Expect(ordererBlock).NotTo(BeNil())
 
 				//join peer1
-				err = channel.JoinChannel(
-					block, org1MSP, peer1Endorser,
-				)
+				err = channel.JoinChannel(specCtx, peer1Connection, org1MSP, block)
 				Expect(err).NotTo(HaveOccurred())
 
 				//join peer2
-				err = channel.JoinChannel(
-					block, org2MSP, peer2Endorser,
-				)
+				err = channel.JoinChannel(specCtx, peer2Connection, org2MSP, block)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			// package chaincode as CCAAS


### PR DESCRIPTION
- Callers no longer need to know about create their own protobuf client stubs. Instead, appropriate client stubs are created using a supplied gRPC connection.
- Callers supply a Context that is used for gRPC invocations, which allows control of timeouts and cancellation of gRPC invocations. Previously invocations used context.Background() and could not be cancelled without terminating the client application.
- Parameters for functions that drive gRPC invocations are of the form 'func(ctx context.Context, connection grpc.ClientConnInterface, id identity.SigningIdentity, ...)`