### PR TITLE
Check for latest patch level in Go vulnerability scan

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.20'
       - name: Generate test mocks
@@ -42,7 +42,7 @@ jobs:
         CREATE_CHANNEL: [create_channel, existing_channel]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.20'
       - run: ./hack/ci.sh ${{matrix.FABRIC_VERSION}} ${{matrix.CREATE_CHANNEL}}

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -3,6 +3,7 @@ name: Security vulnerability scan
 on:
   schedule:
     - cron: '20 02 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -19,9 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.20'
+          check-latest: true
       - name: Scan
         run: make scan-go-${{ matrix.target }}
 
@@ -41,7 +43,7 @@ jobs:
           node-version: 18
       - name: Set up Go
         if: matrix.target == 'osv-scanner'
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.20'
       - name: Scan


### PR DESCRIPTION
Avoids false positives from previous patch levels of the Go standard library after a new Go release.

Also use latest version of actions/setup-go.