### PR TITLE
Remove OSV-Scanner from vulnerability scan

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         target:
           - govulncheck
-          - osv-scanner
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -34,17 +33,11 @@ jobs:
       matrix:
         target:
           - npm-audit
-          - osv-scanner
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Set up Go
-        if: matrix.target == 'osv-scanner'
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.20'
       - name: Scan
         run: make scan-node-${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -41,33 +41,21 @@ golangci-lint: $(go_bin_dir)/golangci-lint
 scan: scan-go scan-node
 
 .PHONEY: scan-go
-scan-go: scan-go-govulncheck scan-go-osv-scanner
+scan-go: scan-go-govulncheck
 
 .PHONEY: scan-go-govulncheck
 scan-go-govulncheck:
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	govulncheck '$(base_dir)/...'
 
-.PHONEY: scan-go-osv-scanner
-scan-go-osv-scanner:
-	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-	osv-scanner --lockfile='$(base_dir)/go.mod'
-
 .PHONEY: scan-node
-scan-node: scan-node-npm-audit scan-node-osv-scanner
+scan-node: scan-node-npm-audit
 
 .PHONEY: scan-node-npm-audit
 scan-node-npm-audit:
 	cd "$(node_dir)/admin" && \
 		npm install --package-lock-only && \
 		npm audit --omit=dev
-
-.PHONEY: scan-node-osv-scanner
-scan-node-osv-scanner:
-	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-	cd "$(node_dir)/admin" && \
-		npm install --package-lock-only && \
-		osv-scanner --lockfile=package-lock.json
 
 .PHONEY: escapes_detect
 escapes_detect:


### PR DESCRIPTION
Running OSV-Scanner on the Node package-lock.json file could also detect vulnerabilities in dev dependencies. The intention of the vulnerability scan is to ensure that the production dependencies do not contain vulnerabilities, not the dev dependencies. This could be resolved by generating a Software Bill of Materials (SBOM) for the Node project, omitting dev dependencies, and running OSV-Scanner on the SBOM. Unfortunately, the use of non-semver tags (such as `latest`) in the dependency tree causes errors in npm ls when generating an SBOM.

Govulncheck and npm audit already do a good job of detecting vulnerabilities in Go and Node respectively so, for now at least, remove OSV-Scanner.