### PR TITLE
Simplify protobuf assignment in unit tests

### DIFF
--- a/pkg/chaincode/approve_test.go
+++ b/pkg/chaincode/approve_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const gatewayEndorseMethod = "/gateway.Gateway/Endorse"
@@ -108,18 +109,18 @@ var _ = Describe("Approve", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
 				endorseCtxErr = ctx.Err()
-				CopyProto(NewEndorseResponse(channelName, ""), out)
+				proto.Merge(out, NewEndorseResponse(channelName, ""))
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.SubmitRequest, out *gateway.SubmitResponse, opts ...grpc.CallOption) {
 				submitCtxErr = ctx.Err()
-				CopyProto(NewSubmitResponse(), out)
+				proto.Merge(out, NewSubmitResponse())
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayCommitStatusMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, method string, in *gateway.SignedCommitStatusRequest, out *gateway.CommitStatusResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewCommitStatusResponse(peer.TxValidationCode_VALID, 0), out)
+				proto.Merge(out, NewCommitStatusResponse(peer.TxValidationCode_VALID, 0))
 				return ctx.Err()
 			})
 
@@ -164,12 +165,12 @@ var _ = Describe("Approve", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
-				CopyProto(NewEndorseResponse(channelName, ""), out)
+				proto.Merge(out, NewEndorseResponse(channelName, ""))
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.SubmitRequest, out *gateway.SubmitResponse, opts ...grpc.CallOption) {
-				CopyProto(NewSubmitResponse(), out)
+				proto.Merge(out, NewSubmitResponse())
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayCommitStatusMethod), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -193,7 +194,7 @@ var _ = Describe("Approve", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
-				CopyProto(NewEndorseResponse(channelName, ""), out)
+				proto.Merge(out, NewEndorseResponse(channelName, ""))
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -226,18 +227,18 @@ var _ = Describe("Approve", func() {
 				Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
 					endorseRequest = in
-					CopyProto(NewEndorseResponse(channelName, ""), out)
+					proto.Merge(out, NewEndorseResponse(channelName, ""))
 				}).
 				Times(1)
 			mockConnection.EXPECT().
 				Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, method string, in *gateway.SubmitRequest, out *gateway.SubmitResponse, opts ...grpc.CallOption) {
-					CopyProto(NewSubmitResponse(), out)
+					proto.Merge(out, NewSubmitResponse())
 				})
 			mockConnection.EXPECT().
 				Invoke(gomock.Any(), gomock.Eq(gatewayCommitStatusMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, method string, in *gateway.SignedCommitStatusRequest, out *gateway.CommitStatusResponse, opts ...grpc.CallOption) {
-					CopyProto(NewCommitStatusResponse(peer.TxValidationCode_VALID, 0), out)
+					proto.Merge(out, NewCommitStatusResponse(peer.TxValidationCode_VALID, 0))
 				})
 
 			mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/checkcommitreadiness_test.go
+++ b/pkg/chaincode/checkcommitreadiness_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ = Describe("CheckCommitReadiness", func() {
@@ -43,7 +44,7 @@ var _ = Describe("CheckCommitReadiness", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateCtxErr = ctx.Err()
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -91,7 +92,7 @@ var _ = Describe("CheckCommitReadiness", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateRequest = in
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			}).
 			Times(1)
 		mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/commit_test.go
+++ b/pkg/chaincode/commit_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ = Describe("Commit", func() {
@@ -45,18 +46,18 @@ var _ = Describe("Commit", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
 				endorseCtxErr = ctx.Err()
-				CopyProto(NewEndorseResponse(channelName, ""), out)
+				proto.Merge(out, NewEndorseResponse(channelName, ""))
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.SubmitRequest, out *gateway.SubmitResponse, opts ...grpc.CallOption) {
 				submitCtxErr = ctx.Err()
-				CopyProto(NewSubmitResponse(), out)
+				proto.Merge(out, NewSubmitResponse())
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayCommitStatusMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, method string, in *gateway.SignedCommitStatusRequest, out *gateway.CommitStatusResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewCommitStatusResponse(peer.TxValidationCode_VALID, 0), out)
+				proto.Merge(out, NewCommitStatusResponse(peer.TxValidationCode_VALID, 0))
 				return ctx.Err()
 			})
 
@@ -101,12 +102,12 @@ var _ = Describe("Commit", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
-				CopyProto(NewEndorseResponse(channelName, ""), out)
+				proto.Merge(out, NewEndorseResponse(channelName, ""))
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.SubmitRequest, out *gateway.SubmitResponse, opts ...grpc.CallOption) {
-				CopyProto(NewSubmitResponse(), out)
+				proto.Merge(out, NewSubmitResponse())
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayCommitStatusMethod), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -130,7 +131,7 @@ var _ = Describe("Commit", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
-				CopyProto(NewEndorseResponse(channelName, ""), out)
+				proto.Merge(out, NewEndorseResponse(channelName, ""))
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -160,18 +161,18 @@ var _ = Describe("Commit", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEndorseMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EndorseRequest, out *gateway.EndorseResponse, opts ...grpc.CallOption) {
 				endorseRequest = in
-				CopyProto(NewEndorseResponse(channelName, ""), out)
+				proto.Merge(out, NewEndorseResponse(channelName, ""))
 			}).
 			Times(1)
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewaySubmitMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.SubmitRequest, out *gateway.SubmitResponse, opts ...grpc.CallOption) {
-				CopyProto(NewSubmitResponse(), out)
+				proto.Merge(out, NewSubmitResponse())
 			})
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(gatewayCommitStatusMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.SignedCommitStatusRequest, out *gateway.CommitStatusResponse, opts ...grpc.CallOption) {
-				CopyProto(NewCommitStatusResponse(peer.TxValidationCode_VALID, 0), out)
+				proto.Merge(out, NewCommitStatusResponse(peer.TxValidationCode_VALID, 0))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/getinstalled_test.go
+++ b/pkg/chaincode/getinstalled_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ = Describe("GetInstalled", func() {
@@ -28,7 +29,7 @@ var _ = Describe("GetInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 				return ctx.Err()
 			})
 
@@ -71,7 +72,7 @@ var _ = Describe("GetInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewErrorProposalResponse(expectedStatus, expectedMessage), out)
+				proto.Merge(out, NewErrorProposalResponse(expectedStatus, expectedMessage))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -98,7 +99,7 @@ var _ = Describe("GetInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -126,7 +127,7 @@ var _ = Describe("GetInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -155,7 +156,7 @@ var _ = Describe("GetInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -189,7 +190,7 @@ var _ = Describe("GetInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(response, out)
+				proto.Merge(out, response)
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/install_test.go
+++ b/pkg/chaincode/install_test.go
@@ -104,13 +104,6 @@ func AssertUnmarshalInvocationSpec(signedProposal *peer.SignedProposal) *peer.Ch
 	return input
 }
 
-func CopyProto(from proto.Message, to proto.Message) {
-	protoBytes, err := proto.Marshal(from)
-	Expect(err).NotTo(HaveOccurred())
-	err = proto.Unmarshal(protoBytes, to)
-	Expect(err).NotTo(HaveOccurred())
-}
-
 var _ = Describe("Install", func() {
 	var packageReader io.Reader
 
@@ -126,7 +119,7 @@ var _ = Describe("Install", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 				return ctx.Err()
 			})
 
@@ -169,7 +162,7 @@ var _ = Describe("Install", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewErrorProposalResponse(expectedStatus, expectedMessage), out)
+				proto.Merge(out, NewErrorProposalResponse(expectedStatus, expectedMessage))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -196,7 +189,7 @@ var _ = Describe("Install", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -221,7 +214,7 @@ var _ = Describe("Install", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -257,7 +250,7 @@ var _ = Describe("Install", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -287,7 +280,7 @@ var _ = Describe("Install", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewSuccessfulProposalResponse(AssertMarshal(expected)), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(AssertMarshal(expected)))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/queryapproved_test.go
+++ b/pkg/chaincode/queryapproved_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ = Describe("QueryApproved", func() {
@@ -40,7 +41,7 @@ var _ = Describe("QueryApproved", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateCtxErr = ctx.Err()
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -87,7 +88,7 @@ var _ = Describe("QueryApproved", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateRequest = in
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			}).
 			Times(1)
 		mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/querycommitted_test.go
+++ b/pkg/chaincode/querycommitted_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ = Describe("QueryCommitted", func() {
@@ -36,7 +37,7 @@ var _ = Describe("QueryCommitted", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateCtxErr = ctx.Err()
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -80,7 +81,7 @@ var _ = Describe("QueryCommitted", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateRequest = in
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			}).
 			Times(1)
 		mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/querycommittedwithname_test.go
+++ b/pkg/chaincode/querycommittedwithname_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ = Describe("QueryCommittedWithName", func() {
@@ -38,7 +39,7 @@ var _ = Describe("QueryCommittedWithName", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateCtxErr = ctx.Err()
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -84,7 +85,7 @@ var _ = Describe("QueryCommittedWithName", func() {
 			Invoke(gomock.Any(), gomock.Eq(gatewayEvaluateMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *gateway.EvaluateRequest, out *gateway.EvaluateResponse, opts ...grpc.CallOption) {
 				evaluateRequest = in
-				CopyProto(NewEvaluateResponse(""), out)
+				proto.Merge(out, NewEvaluateResponse(""))
 			}).
 			Times(1)
 		mockSigner := NewMockSigner(controller, "", nil, nil)

--- a/pkg/chaincode/queryinstalled_test.go
+++ b/pkg/chaincode/queryinstalled_test.go
@@ -40,7 +40,7 @@ var _ = Describe("QueryInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) error {
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 				return ctx.Err()
 			})
 
@@ -83,7 +83,7 @@ var _ = Describe("QueryInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(NewErrorProposalResponse(expectedStatus, expectedMessage), out)
+				proto.Merge(out, NewErrorProposalResponse(expectedStatus, expectedMessage))
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)
@@ -110,7 +110,7 @@ var _ = Describe("QueryInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -138,7 +138,7 @@ var _ = Describe("QueryInstalled", func() {
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
-				CopyProto(NewSuccessfulProposalResponse(nil), out)
+				proto.Merge(out, NewSuccessfulProposalResponse(nil))
 			}).
 			Times(1)
 
@@ -174,7 +174,7 @@ var _ = Describe("QueryInstalled", func() {
 		mockConnection.EXPECT().
 			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
-				CopyProto(response, out)
+				proto.Merge(out, response)
 			})
 
 		mockSigner := NewMockSigner(controller, "", nil, nil)


### PR DESCRIPTION
Since protobuf messages cannot be shallow copied, serialization was previously used to assign the state of an expected protobuf to a gRPC service response parameter when mocking gRPC service invocations. This can be replaced by using the `proto.Merge()` utility function, which achieves the same result without the overhead of serialization.