### PR TITLE
Address false positive for CVE-2024-21484

### DIFF
--- a/node/admin/package.json
+++ b/node/admin/package.json
@@ -14,8 +14,8 @@
     "test": "mocha test"
   },
   "dependencies": {
-    "fabric-ca-client": "latest",
-    "fabric-common": "latest",
+    "fabric-ca-client": "unstable",
+    "fabric-common": "unstable",
     "@hyperledger-twgc/fabric-formatter": "file:../formatter",
     "form-data": "latest",
     "@davidkhala/crypto": "latest"


### PR DESCRIPTION
This vulnerability only relates to the Node implementation and impacts RSA encryption, which is not used by Fabric.

Update to development versions of fabric-sdk-node packages where dependencies have been updated only to avoid vulnerability scan failures.