### PR TITLE
Update Go version used for vulnerability scan

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -31,7 +31,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          skip-pkg-cache: true
 
   end-to-end:
     runs-on: ubuntu-latest

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: stable
           check-latest: true
       - name: Scan
         run: make scan-go-${{ matrix.target }}


### PR DESCRIPTION
Run vulnerability scan with latest currently suported Go release to avoid failures caused by old standard library versions.

Also remove deprecated `skip-pkg-cache` argument from golangci-lint-action.