### PR TITLE
Fix Go build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+max_line_length = 120
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.html]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+
+[*.{mj,cj,j,t}s]
+quote_type = single

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: "1.21"
       - name: Generate test mocks
         run: make generate
       - name: Unit test
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: stable
       - name: Generate test mocks
         run: make generate
       - name: Staticcheck
@@ -38,29 +38,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - FABRIC_VERSION: '2.5.3'
-            CREATE_CHANNEL: 'create_channel'
+          - FABRIC_VERSION: "2.5.3"
+            CREATE_CHANNEL: "create_channel"
             CONSENSUS: RAFT
-          - FABRIC_VERSION: '2.5.3'
-            CREATE_CHANNEL: 'existing_channel'
+          - FABRIC_VERSION: "2.5.3"
+            CREATE_CHANNEL: "existing_channel"
             CONSENSUS: RAFT
-          - FABRIC_VERSION: '3.0.0-preview'
-            CREATE_CHANNEL: 'create_channel'
+          - FABRIC_VERSION: "3.0.0-preview"
+            CREATE_CHANNEL: "create_channel"
             CONSENSUS: RAFT
-          - FABRIC_VERSION: '3.0.0-preview'
-            CREATE_CHANNEL: 'existing_channel'
+          - FABRIC_VERSION: "3.0.0-preview"
+            CREATE_CHANNEL: "existing_channel"
             CONSENSUS: RAFT
-          - FABRIC_VERSION: '3.0.0-preview'
-            CREATE_CHANNEL: 'create_channel'
+          - FABRIC_VERSION: "3.0.0-preview"
+            CREATE_CHANNEL: "create_channel"
             CONSENSUS: BFT
-          - FABRIC_VERSION: '3.0.0-preview'
-            CREATE_CHANNEL: 'existing_channel'
+          - FABRIC_VERSION: "3.0.0-preview"
+            CREATE_CHANNEL: "existing_channel"
             CONSENSUS: BFT
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: "1.21"
       - name: run end to end test
         env:
           FABRIC_VERSION: ${{matrix.FABRIC_VERSION}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   go:
     uses: ./.github/workflows/golang.yml
-  
+
   node:
     uses: ./.github/workflows/node.yml
 
@@ -23,4 +23,4 @@ jobs:
     name: Pull request success
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: "true"

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,11 +2,12 @@ name: Scheduled build
 
 on:
   schedule:
-    - cron: "10 01 * * *"
+    - cron: "10 01 * * 0"
+  workflow_dispatch:
 
 jobs:
   go:
     uses: ./.github/workflows/golang.yml
-  
+
   node:
     uses: ./.github/workflows/node.yml

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -2,7 +2,7 @@ name: Security vulnerability scan
 
 on:
   schedule:
-    - cron: '20 02 * * *'
+    - cron: "20 02 * * 0"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The lint job failed as the Go version used was too old to run current versions of staticcheck.

Additionally, this change sets the scheduled build and security vulnerability scan to run weekly instead of daily, since the rate of change in the project is low. Both are also configured to be runnable on demand from the GitHub UI.