### PR TITLE
Run vulnerability scan on latest release version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,9 @@ jobs:
   node:
     uses: ./.github/workflows/node.yml
 
+  scan:
+    uses: ./.github/workflows/scan.yml
+
   pull-request:
     needs:
       - go

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,41 @@
+name: Security vulnerability scan
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Branch, tag or SHA to scan.
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          check-latest: true
+      - name: Scan
+        run: make scan-go
+
+  node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Scan
+        run: make scan-node

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -9,35 +9,18 @@ permissions:
   contents: read
 
 jobs:
-  go:
+  latest-release-version:
+    name: Get latest release tag
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - govulncheck
+    outputs:
+      tag_name: ${{ steps.tag-name.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          check-latest: true
-      - name: Scan
-        run: make scan-go-${{ matrix.target }}
+      - id: tag-name
+        run: echo "value=$(curl --location --silent --fail "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq --raw-output '.tag_name')" >> "${GITHUB_OUTPUT}"
 
-  node:
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - npm-audit
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - name: Scan
-        run: make scan-node-${{ matrix.target }}
+  scan:
+    name: Scan ${{ needs.latest-release-version.outputs.tag_name }}
+    needs: latest-release-version
+    uses: ./.github/workflows/scan.yml
+    with:
+      ref: ${{ needs.latest-release-version.outputs.tag_name }}


### PR DESCRIPTION
Previously the scan ran on the current state of the codebase. This fails to identify vulnerabilities in dependencies for the latest release version if those dependencies have already been updated in the development codebase. The gating factor for whether a new release is required should be whether the previous release contains vulnerabilities.

This change runs the scheduled vulnerability scan on the latest release tag. It also adds vulnerability scanning to pull request builds. This is purely informational. A scan failure does not fail the pull request build.