### PR TITLE
Remove Node vulnerability scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -27,15 +27,15 @@ jobs:
       - name: Scan
         run: make scan-go
 
-  node:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - name: Scan
-        run: make scan-node
+  # node:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.ref }}
+  #     - name: Use Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 18
+  #     - name: Scan
+  #       run: make scan-node


### PR DESCRIPTION
The Node implementation is not yet stabilized and depends on the legacy Fabric Node SDK. The dependency tree now includes dependencies that contain known vulnerabilities.

This change disables the the vulnerability scan for the Node implementation so that the vulnerability status of the Go implementation can be more clearly observed from scan results.